### PR TITLE
Update readme: install kernel module beforing starting ovn-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,18 @@ Start the OVS and OVN processes using the script in this repository:
     ./scripts/start-ovn.sh -t aio
 
 *Note*: the above command uses the script to start an all-in-one mode OVN. Refer
-to the [multihost]() for setting up docker cluster.
+to the [multihost](https://github.com/huikang/libnetwork-ovn-plugin/blob/master/docs/multihost-ovn.md) for setting up docker cluster.
 
 
 To very the host has been connected to the OVN centralized controller, type
 
     docker exec ovn-central ovn-sbctl show
+
+Also verify that the br-int is created with correct kernel module by:
+
+    docker exec aio ovs-ofctl dump-flows br-int
+
+The above command should return with no error.
 
 ## Start plugins
 

--- a/docs/multihost-ovn.md
+++ b/docs/multihost-ovn.md
@@ -29,6 +29,8 @@ To see the docker host has registered itself to the cluster, run:
 
 ## Start the ovn centralized node
 
+**Important**: before starting the OVN container, make sure the correct OVS kernel modules are loaded. Otherwise the ovs-vswitch process must be restarted.
+
     go get github.com/huikang/libnetwork-ovn-plugin
     ./scripts/start-ovn.sh -t aio -r ${CENTRALNODEIP} -s ${CENTRALNODEIP}
 


### PR DESCRIPTION
Creating br-int requires kernel module. Otherwise "ovs-ofctl dump-flows br-int"
returns error

Signed-off-by: Hui Kang <kangh@us.ibm.com>